### PR TITLE
Improve player name mapping

### DIFF
--- a/COMPLETE_SYSTEM_GUIDE.md
+++ b/COMPLETE_SYSTEM_GUIDE.md
@@ -190,9 +190,10 @@ CREATE TABLE plus_ev_bets (
 -- Player name mapping (CRITICAL: must have mapping_type column)
 CREATE TABLE player_name_mapping (
     id INTEGER PRIMARY KEY,
-    canonical_name TEXT,
-    variant_name TEXT,
-    mapping_type TEXT,  -- THIS COLUMN WAS MISSING INITIALLY
+    betting_name TEXT NOT NULL,
+    mlb_name TEXT NOT NULL,
+    team TEXT,
+    mapping_type TEXT,  -- e.g. 'manual' or 'auto'
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This is a complete, automated MLB props betting system that:
 - Supports 20+ different market types
 - Calculates actual results vs betting lines
 - High confidence auto-resolution (95%)
-- Player name mapping system
+- Player name mapping system (stored in `player_name_mapping` table)
 
 **Supported Markets**:
 - Batting: Hits, Runs, RBIs, Home Runs, Doubles, Triples, Singles


### PR DESCRIPTION
## Summary
- create `player_name_mapping` table in the database
- add methods to insert and query name mappings
- store auto mappings when resolving bets
- simplify resolver mapping lookup
- document player name mapping table in README and guide

## Testing
- `python -m py_compile enhanced_bet_resolver.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_6867e1f3136c8328b70ba118e4d9fc82