### PR TITLE
Fix tier breakdown comparisons

### DIFF
--- a/daily_scraper.py
+++ b/daily_scraper.py
@@ -163,14 +163,14 @@ class DailyMLBScraper:
         tier_counts = {'A': 0, 'B': 0, 'C': 0, 'D': 0, 'None': 0}
         
         for record in data:
-            ev_tier = record.get('ev_tier_parsed', 'No data')
-            if 'Tier A' in ev_tier:
+            ev_tier = record.get('ev_tier_parsed')
+            if ev_tier == 'A':
                 tier_counts['A'] += 1
-            elif 'Tier B' in ev_tier:
+            elif ev_tier == 'B':
                 tier_counts['B'] += 1
-            elif 'Tier C' in ev_tier:
+            elif ev_tier == 'C':
                 tier_counts['C'] += 1
-            elif 'Tier D' in ev_tier:
+            elif ev_tier == 'D':
                 tier_counts['D'] += 1
             else:
                 tier_counts['None'] += 1


### PR DESCRIPTION
## Summary
- replace substring checks with direct equality in `calculate_tier_breakdown`
- count `None` tier when value isn't A–D

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab82047f88328bf7a495fb9dec21d