### PR TITLE
Ensure consistent team abbreviations

### DIFF
--- a/enhanced_bet_resolver.py
+++ b/enhanced_bet_resolver.py
@@ -136,8 +136,10 @@ class EnhancedBetResolver:
         name = re.sub(r'\s+(jr\.?|sr\.?|iii?|iv)$', '', name)
         name = re.sub(r'[^\w\s]', '', name)  # Remove punctuation
         name = re.sub(r'\s+', ' ', name)     # Normalize whitespace
-        
-        return f"{name}_{team.upper()}"
+
+        team_abbr = self.db.normalize_team_abbreviation(team)
+
+        return f"{name}_{team_abbr}"
     
     def _resolve_single_bet(self, bet: Dict, box_score_lookup: Dict[str, Dict]) -> bool:
         """Resolve a single bet using box score data"""


### PR DESCRIPTION
## Summary
- normalize team abbreviations with a mapping table
- store normalized abbreviations when importing props
- use normalized abbreviations when inserting games and players
- update bet resolver to normalize team abbreviations when matching box scores

## Testing
- `python3 -m py_compile database.py enhanced_bet_resolver.py`
- `python3 enhanced_bet_resolver.py`

------
https://chatgpt.com/codex/tasks/task_e_686c084455a88328a82e2c9f5d33dd56