### PR TITLE
Fix earned run market detection

### DIFF
--- a/enhanced_bet_resolver.py
+++ b/enhanced_bet_resolver.py
@@ -223,7 +223,7 @@ class EnhancedBetResolver:
         elif 'single' in market_lower:
             return float(box_score.get('singles', 0))
             
-        elif 'walk' in market_lower or 'base on balls' in market_lower:
+        elif ('walk' in market_lower and 'allowed' not in market_lower) or 'base on balls' in market_lower:
             return float(box_score.get('walks', 0))
             
         elif 'strikeout' in market_lower and 'pitcher' not in market_lower:
@@ -251,7 +251,7 @@ class EnhancedBetResolver:
         elif 'strikeout' in market_lower and ('pitcher' in market_lower or 'pitching' in market_lower):
             return float(box_score.get('strikeouts_pitched', 0))
             
-        elif 'earned run' in market_lower or 'er' in market_lower:
+        elif 'earned run' in market_lower or re.search(r"\ber\b", market, re.IGNORECASE):
             return float(box_score.get('earned_runs', 0))
             
         elif 'hits allowed' in market_lower:

--- a/test_market_parsing.py
+++ b/test_market_parsing.py
@@ -1,0 +1,38 @@
+import unittest
+from enhanced_bet_resolver import EnhancedBetResolver
+
+class DummyDB:
+    pass
+
+class MarketParsingTests(unittest.TestCase):
+    def setUp(self):
+        self.resolver = EnhancedBetResolver(DummyDB())
+        self.box_score = {
+            'earned_runs': 2,
+            'strikeouts_pitched': 8,
+            'walks_allowed': 3,
+            'walks': 1
+        }
+
+    def test_earned_run_phrase(self):
+        result = self.resolver._calculate_actual_result('earned runs allowed', self.box_score)
+        self.assertEqual(result, 2.0)
+
+    def test_earned_run_abbrev(self):
+        result = self.resolver._calculate_actual_result('ER', self.box_score)
+        self.assertEqual(result, 2.0)
+
+    def test_er_not_in_pitcher(self):
+        result = self.resolver._calculate_actual_result('Pitcher Strikeouts', self.box_score)
+        self.assertEqual(result, 8.0)
+
+    def test_walks_allowed(self):
+        result = self.resolver._calculate_actual_result('Walks Allowed', self.box_score)
+        self.assertEqual(result, 3.0)
+
+    def test_walks_hitter(self):
+        result = self.resolver._calculate_actual_result('Walks', self.box_score)
+        self.assertEqual(result, 1.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- tighten earned run market detection to look for `"ER"` as a separate word
- avoid misclassifying `Walks Allowed` props by ignoring `walks allowed` in batter markets
- add lightweight tests ensuring market parsing is correct

## Testing
- `python3 -m unittest test_market_parsing.py`

------
https://chatgpt.com/codex/tasks/task_e_686c0844032083289752342435b85262